### PR TITLE
Remove wait in kbar test

### DIFF
--- a/apps/main/cypress/e2e/kbar.cy.ts
+++ b/apps/main/cypress/e2e/kbar.cy.ts
@@ -1,13 +1,13 @@
 /// <reference types="cypress" />
 
 describe("Kbar", function () {
-	this.beforeEach(() => {
-		cy.viewport("macbook-13")
-		cy.visit("/")
-		cy.get("body").type("{esc}{esc}")
-		// FIXME: this is a workaround for cypress to wait for the kbar component to load
-		cy.wait(1500)
-	})
+        this.beforeEach(() => {
+                cy.viewport("macbook-13")
+                cy.visit("/")
+                cy.get("body").type("{esc}{esc}")
+                // wait for kbar component button to appear
+                cy.get('[data-cy="cmdkbutton"]').should('be.visible')
+        })
 
 	context("enter key combination cmd + k", () => {
 		it("should display kbar background and panel", function () {


### PR DESCRIPTION
## Summary
- update kbar e2e test to remove fixed wait time
- ensure cmd+k button is visible before continuing

## Testing
- `pnpm lint:main`
- `pnpm test:main` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429501c3d88325ad18bd764c4ec4cd